### PR TITLE
Replace dash with dash-functional

### DIFF
--- a/org-recent-headings.el
+++ b/org-recent-headings.el
@@ -70,7 +70,7 @@
 (require 'recentf)
 (require 'seq)
 
-(require 'dash)
+(require 'dash-functional)
 (require 'frecency)
 
 ;;;; Structs


### PR DESCRIPTION
Hi.

When I tried to use `org-recent-headings`, an error was occurred with a message like `-on` is missing. I just quickly checked the dependencies of this package. Then I found `(require 'dash)` should be replaced with `dash-functional`.