### PR TITLE
Add org-clock-history source to org-recent-headings-helm

### DIFF
--- a/org-recent-headings.el
+++ b/org-recent-headings.el
@@ -291,11 +291,14 @@ With prefix argument ARG, turn on if positive, otherwise off."
 
   (defun org-recent-headings--clock-history-entries ()
     "Create entries from `org-clock-history'."
-    (mapcar (lambda (marker)
-              (with-current-buffer (marker-buffer marker)
-                (org-with-wide-buffer)
-                (goto-char marker)
-                (org-recent-headings--current-entry)))
+    (mapcar (delq nil
+                  (lambda (marker)
+                    (let ((buffer (marker-buffer marker)))
+                      (when (buffer-live-p buffer)
+                        (with-current-buffer buffer
+                          (org-with-wide-buffer)
+                          (goto-char marker)
+                          (org-recent-headings--current-entry))))))
             org-clock-history))
 
   (defun org-recent-headings--show-entry-indirect-helm-action ()

--- a/org-recent-headings.el
+++ b/org-recent-headings.el
@@ -250,6 +250,16 @@ With prefix argument ARG, turn on if positive, otherwise off."
       map)
     "Keymap for `helm-source-org-recent-headings'.")
 
+  (defcustom org-recent-headings-helm-actions
+    (helm-make-actions
+     "Show entry (default function)" 'org-recent-headings--show-entry-default
+     "Show entry in real buffer" 'org-recent-headings--show-entry-direct
+     "Show entry in indirect buffer" 'org-recent-headings--show-entry-indirect
+     "Remove entry" 'org-recent-headings-helm-remove-entries
+     "Bookmark heading" 'org-recent-headings--bookmark-entry)
+    "List of actions for `org-clock-headings-helm'."
+    :group 'org-recent-headings)
+
   (defvar helm-source-org-recent-headings
     (helm-build-sync-source " Recent Org headings"
       :candidates (lambda ()
@@ -271,16 +281,6 @@ With prefix argument ARG, turn on if positive, otherwise off."
       :keymap org-recent-headings-helm-map
       :action org-recent-headings-helm-actions)
     "Helm source for `org-recent-headings'.")
-
-  (defcustom org-recent-headings-helm-actions
-    (helm-make-actions
-     "Show entry (default function)" 'org-recent-headings--show-entry-default
-     "Show entry in real buffer" 'org-recent-headings--show-entry-direct
-     "Show entry in indirect buffer" 'org-recent-headings--show-entry-indirect
-     "Remove entry" 'org-recent-headings-helm-remove-entries
-     "Bookmark heading" 'org-recent-headings--bookmark-entry)
-    "List of actions for `org-clock-headings-helm'."
-    :group 'org-recent-headings)
 
   (defcustom org-recent-headings-helm-show-clock-history nil
     "Whether and how to display the clock history in `org-recent-headings-helm'."


### PR DESCRIPTION
Hi,

I noticed that `org-clock-history` is analogous to `org-recent-headings`. As Helm is a nice interface for working with multiple sources, I created a clock history source, so they can provide the same features through a single package. With this patch, you can append/prepend the clock history to `org-recent-headings-helm` by customizing `org-recent-headings-helm-show-clock-history`.

For now, you cannot remove an entry from the clock history using the remove action in the command. Apparently, it can be implemented by working around `org-recent-headings-helm-remove-entries`, but I don't know what is the best way to implement the feature.