### PR TITLE
Move org-recent-headings-candidate-number-limit custom variable

### DIFF
--- a/helm-org-recent-headings.el
+++ b/helm-org-recent-headings.el
@@ -38,6 +38,13 @@
 (require 'org-recent-headings)
 
 ;;;; Variables
+(define-obsolete-variable-alias 'org-recent-headings-candidate-number-limit
+  'helm-org-recent-headings-candidate-number-limit
+  "0.2")
+
+(defcustom helm-org-recent-headings-candidate-number-limit 10
+  "Number of candidates to display in Helm source."
+  :type 'integer)
 
 (defvar helm-org-recent-headings-map
   (let ((map (copy-keymap helm-map)))
@@ -50,7 +57,7 @@
     :candidates (lambda ()
                   (org-recent-headings--prepare-list)
                   org-recent-headings-list)
-    :candidate-number-limit 'org-recent-headings-candidate-number-limit
+    :candidate-number-limit 'helm-org-recent-headings-candidate-number-limit
     :candidate-transformer 'helm-org-recent-headings--truncate-candidates
     ;; FIXME: If `helm-org-recent-headings-map' is changed after this `defvar' is
     ;; evaluated, the keymap used in the source is not changed, which is very confusing

--- a/org-recent-headings.el
+++ b/org-recent-headings.el
@@ -115,10 +115,6 @@ an agenda buffer)."
   "Hooks to add heading-storing function to."
   :type '(repeat variable))
 
-(defcustom org-recent-headings-candidate-number-limit 10
-  "Number of candidates to display in Helm source."
-  :type 'integer)
-
 (defcustom org-recent-headings-save-file (locate-user-emacs-file "org-recent-headings")
   "File to save the recent Org headings list into."
   :type 'file


### PR DESCRIPTION
After the recent package separation of `helm-org-recent-headings` from `org-recent-headings`, `org-recent-headings-candidate-number-limit` variable is no longer used in `org-recent-headings` package. I think it is necessary to move the variable to `helm-org-recent-headings`.