### PR TITLE
Change: Don't depend on deprecated dash-functional

### DIFF
--- a/helm-org-recent-headings.el
+++ b/helm-org-recent-headings.el
@@ -5,7 +5,7 @@
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; Url: http://github.com/alphapapa/org-recent-headings
 ;; Version: 0.2-pre
-;; Package-Requires: ((emacs "26.1") (org "9.0.5") (dash "2.13.0") (helm "1.9.4") (org-recent-headings "0.2-pre") (s "1.12.0"))
+;; Package-Requires: ((emacs "26.1") (org "9.0.5") (dash "2.18.0") (helm "1.9.4") (org-recent-headings "0.2-pre") (s "1.12.0"))
 ;; Keywords: hypermedia, outlines, Org
 
 ;; This program is free software; you can redistribute it and/or modify

--- a/org-recent-headings.el
+++ b/org-recent-headings.el
@@ -3,7 +3,7 @@
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; Url: http://github.com/alphapapa/org-recent-headings
 ;; Version: 0.2-pre
-;; Package-Requires: ((emacs "26.1") (org "9.0.5") (dash "2.13.0") (dash-functional "1.2.0") (frecency "0.1") (s "1.12.0"))
+;; Package-Requires: ((emacs "26.1") (org "9.0.5") (dash "2.18.0") (frecency "0.1") (s "1.12.0"))
 ;; Keywords: hypermedia, outlines, Org
 
 ;;; Commentary:
@@ -71,7 +71,6 @@
 (require 'subr-x)
 
 (require 'dash)
-(require 'dash-functional)
 (require 'frecency)
 (require 's)
 


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218